### PR TITLE
add locate-errors command

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,75 @@ Print out the Nile version
 nile version
 ```
 
+### `locate-error`
+Use locally available contracts to make error messages from rejected transactions more explicit.  
+
+```sh
+nile locate-error <transaction_hash> [CONTRACTS_FILE, NETWORK]
+```
+
+For example, this transaction returns the very cryptic error message:  
+`An ASSERT_EQ instruction failed: 0 != 1.`
+
+```sh
+starknet tx_status \
+  --hash 0x57d2d844923f9fe5ef54ed7084df61f926b9a2a24eb5d7e46c8f6dbcd4baafe \
+  --error_message
+
+[...]
+Error in the called contract (0x5bf05eece944b360ff0098eb9288e49bd0007e5a9ed80aefcb740e680e67ea4):
+Error at pc=0:1360:
+An ASSERT_EQ instruction failed: 0 != 1.
+Cairo traceback (most recent call last):
+Unknown location (pc=0:1384)
+Unknown location (pc=0:1369)
+```
+
+This can be made more explicit with:
+
+```sh
+nile locate-error 0x57d2d844923f9fe5ef54ed7084df61f926b9a2a24eb5d7e46c8f6dbcd4baafe
+
+⏳ Querying the network to check transaction status and identify contracts...
+🧾 Found contracts: ['0x05bf05eece944b360ff0098eb9288e49bd0007e5a9ed80aefcb740e680e67ea4:artifacts/Evaluator.json']
+⏳ Querying the network with contracts...
+🧾 Error message:
+
+[...]
+Error in the called contract (0x5bf05eece944b360ff0098eb9288e49bd0007e5a9ed80aefcb740e680e67ea4):
+[path_to_file]:179:5: Error at pc=0:1360:
+    assert permission = 1
+    ^*******************^
+An ASSERT_EQ instruction failed: 0 != 1.
+Cairo traceback (most recent call last):
+[path_to_file]:184:6
+func set_teacher{
+     ^*********^
+[path_to_file]:189:5
+    only_teacher()
+    ^************^
+```
+
+In case of pending transaction states, the command will offer to continue probing the network unless it
+is terminated prematurely.
+This example also shows how accepted transactions are handled.
+
+```sh
+⏳ Querying the network to check transaction status and identify contracts...
+🕒 Transaction status: RECEIVED. Trying again in 30 seconds unless stopped.
+🕒 Transaction status: RECEIVED. Trying again in 30 seconds unless stopped.
+🕒 Transaction status: PENDING. Trying again in 30 seconds unless stopped.
+✅ Transaction status: ACCEPTED_ON_L2. No error in transaction.
+```
+
+Finally, the command will use the local `network.deployments.txt` files to fetch the available contracts.  
+However, it is also possible to override this by passing a `CONTRACTS_FILE` argument, formatted as
+```
+CONTRACT_ADDRESS1:PATH_TO_COMPILED_CONTRACT1.json
+CONTRACT_ADDRESS2:PATH_TO_COMPILED_CONTRACT2.json
+...
+```
+
 ## Hacking on Nile
 
 Nile uses tox to manage development tasks, you can get a list of

--- a/src/nile/cli.py
+++ b/src/nile/cli.py
@@ -15,6 +15,7 @@ from nile.core.node import node as node_command
 from nile.core.run import run as run_command
 from nile.core.test import test as test_command
 from nile.core.version import version as version_command
+from nile.utils.debug import locate_error as locate_error_command
 
 logging.basicConfig(level=logging.DEBUG, format="%(message)s")
 
@@ -183,6 +184,15 @@ def node(host, port):
 def version():
     """Print out toolchain version."""
     version_command()
+
+
+@cli.command()
+@click.argument("tx_hash", nargs=1)
+@network_option
+@click.option("--contracts_file", nargs=1)
+def locate_error(tx_hash, network, contracts_file):
+    """Locate an error in a transaction using contracts."""
+    locate_error_command(tx_hash, network, contracts_file)
 
 
 if __name__ == "__main__":

--- a/src/nile/common.py
+++ b/src/nile/common.py
@@ -9,6 +9,7 @@ ABIS_DIRECTORY = f"{BUILD_DIRECTORY}/abis"
 DEPLOYMENTS_FILENAME = "deployments.txt"
 ACCOUNTS_FILENAME = "accounts.json"
 NODE_FILENAME = "node.json"
+RETRY_AFTER_PERIOD = {"seconds": 30, "label": "30 seconds"}
 
 
 def _get_gateway():

--- a/src/nile/utils/debug.py
+++ b/src/nile/utils/debug.py
@@ -1,0 +1,89 @@
+"""Functions used to help debug a rejected transaction."""
+
+import json
+import logging
+import os
+import re
+import subprocess
+import time
+
+from nile.common import BUILD_DIRECTORY, DEPLOYMENTS_FILENAME, GATEWAYS
+
+
+def locate_error(tx_hash, network, contracts_file=None):
+    """Use available contracts to help locate the error in a rejected transaction."""
+    command = ["starknet", "tx_status", "--hash", tx_hash]
+
+    if network == "mainnet":
+        os.environ["STARKNET_NETWORK"] = "alpha-mainnet"
+    elif network == "goerli":
+        os.environ["STARKNET_NETWORK"] = "alpha-goerli"
+    else:
+        command.append(f"--gateway_url={GATEWAYS.get(network)}")
+
+    logging.info(
+        "⏳ Querying the network to check transaction status and identify contracts..."
+    )
+
+    while True:
+        receipt = json.loads(subprocess.check_output(command))
+        status = receipt["tx_status"]
+        if status == "REJECTED":
+            break
+        output = f"Transaction status: {status}"
+        if status.startswith("ACCEPTED"):
+            logging.info(f"✅ {output}. No error in transaction.")
+            return
+        logging.info(f"🕒 {output}. Trying again in 30 seconds unless stopped.")
+        time.sleep(30)
+
+    error_message = receipt["tx_failure_reason"]["error_message"]
+    addresses = set(
+        int(address, 16)
+        for address in re.findall("0x[\\da-f]{1,64}", str(error_message))
+    )
+
+    if not addresses:
+        logging.warning(
+            "🛑 The transaction was rejected but no contract address was identified "
+            "in the error message."
+        )
+        logging.info(f"Error message:\n{error_message}")
+        return error_message
+
+    file = contracts_file or f"{network}.{DEPLOYMENTS_FILENAME}"
+    # contracts_file should already link to compiled contracts and not ABIs
+    to_contract = (lambda x: x) if contracts_file else _abi_to_build_path
+
+    contracts = []
+    with open(file) as file_stream:
+        for line_idx, line in enumerate(file_stream):
+            try:
+                line_address, abi = line.split(":")
+            except ValueError:
+                logging.warning(
+                    f"⚠ Skipping misformatted line #{line_idx+1} in {file}."
+                )
+                continue
+            if int(line.split(":")[0], 16) in addresses:
+                contracts.append(f"{line_address}:{to_contract(abi.rstrip())}")
+
+    if not contracts:
+        logging.warning(
+            "🛑 The transaction was rejected but no contract data is locally "
+            "available to improve the error message."
+        )
+        logging.info(error_message)
+        return error_message
+
+    command += ["--contracts", ",".join(contracts), "--error_message"]
+    logging.info(f"🧾 Found contracts: {contracts}")
+    logging.info("⏳ Querying the network with identified contracts...")
+    output = subprocess.check_output(command)
+
+    logging.info(f"🧾 Error message:\n{output.decode()}")
+    return output
+
+
+def _abi_to_build_path(filename):
+    return os.path.join(BUILD_DIRECTORY, os.path.basename(filename))

--- a/src/nile/utils/debug.py
+++ b/src/nile/utils/debug.py
@@ -7,7 +7,12 @@ import re
 import subprocess
 import time
 
-from nile.common import BUILD_DIRECTORY, DEPLOYMENTS_FILENAME, GATEWAYS
+from nile.common import (
+    BUILD_DIRECTORY,
+    DEPLOYMENTS_FILENAME,
+    GATEWAYS,
+    RETRY_AFTER_PERIOD,
+)
 
 
 def locate_error(tx_hash, network, contracts_file=None):
@@ -34,8 +39,10 @@ def locate_error(tx_hash, network, contracts_file=None):
         if status.startswith("ACCEPTED"):
             logging.info(f"✅ {output}. No error in transaction.")
             return
-        logging.info(f"🕒 {output}. Trying again in 30 seconds unless stopped.")
-        time.sleep(30)
+
+        retry_period = RETRY_AFTER_PERIOD["label"]
+        logging.info(f"🕒 {output}. Trying again in {retry_period} unless stopped.")
+        time.sleep(RETRY_AFTER_PERIOD["seconds"])
 
     error_message = receipt["tx_failure_reason"]["error_message"]
     addresses = set(


### PR DESCRIPTION
This command enables locating errors in locally-compiled/available contracts
from a rejected transaction hash.
